### PR TITLE
Added more TPM Resource API:s (#54)

### DIFF
--- a/src/abstraction/transient.rs
+++ b/src/abstraction/transient.rs
@@ -18,7 +18,7 @@ use crate::response_code::{Error, Result, WrapperErrorKind as ErrorKind};
 use crate::tss2_esys::*;
 use crate::utils::algorithm_specifiers::Cipher;
 use crate::utils::{
-    self, get_rsa_public, Hierarchy, PublicIdUnion, TpmaSession, TpmsContext, TpmtTkVerified,
+    self, get_rsa_public, Hierarchy, PublicIdUnion, TpmaSessionBuilder, TpmsContext, TpmtTkVerified,
 };
 use crate::{Context, Tcti};
 use log::error;
@@ -188,7 +188,7 @@ impl TransientKeyContext {
         self.set_session_attrs()?;
         let key_handle = self.context.context_load(key_context)?;
         self.context
-            .set_handle_auth(key_handle, key_auth)
+            .tr_set_auth(key_handle, key_auth)
             .or_else(|e| {
                 self.context.flush_context(key_handle)?;
                 Err(e)
@@ -256,10 +256,11 @@ impl TransientKeyContext {
     /// * if `Context::set_session_attr` returns an error, that error is propagated through
     fn set_session_attrs(&mut self) -> Result<()> {
         let (session, _, _) = self.context.sessions();
-        let session_attr = utils::TpmaSession::new()
+        let session_attr = utils::TpmaSessionBuilder::new()
             .with_flag(TPMA_SESSION_DECRYPT)
-            .with_flag(TPMA_SESSION_ENCRYPT);
-        self.context.set_session_attr(session, session_attr)?;
+            .with_flag(TPMA_SESSION_ENCRYPT)
+            .build();
+        self.context.tr_sess_set_attributes(session, session_attr)?;
         Ok(())
     }
 }
@@ -380,10 +381,11 @@ impl TransientKeyContextBuilder {
             self.session_encr_cipher.into(),
             self.session_hash_alg,
         )?;
-        let session_attr = TpmaSession::new()
+        let session_attr = TpmaSessionBuilder::new()
             .with_flag(TPMA_SESSION_DECRYPT)
-            .with_flag(TPMA_SESSION_ENCRYPT);
-        context.set_session_attr(session, session_attr)?;
+            .with_flag(TPMA_SESSION_ENCRYPT)
+            .build();
+        context.tr_sess_set_attributes(session, session_attr)?;
 
         context.set_sessions((session, ESYS_TR_NONE, ESYS_TR_NONE));
         let root_key_auth: Vec<u8> = if self.root_key_auth_size > 0 {
@@ -392,7 +394,7 @@ impl TransientKeyContextBuilder {
             vec![]
         };
         if !self.hierarchy_auth.is_empty() {
-            context.set_handle_auth(self.hierarchy.esys_rh(), &self.hierarchy_auth)?;
+            context.tr_set_auth(self.hierarchy.esys_rh(), &self.hierarchy_auth)?;
         }
 
         let root_key_handle = context.create_primary_key(

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -648,28 +648,71 @@ impl TryFrom<Signature> for TPMT_SIGNATURE {
 
 /// Rust native wrapper for session attributes objects.
 #[derive(Copy, Clone, Debug, Default)]
-pub struct TpmaSession(TPMA_SESSION);
+pub struct TpmaSession {
+    flags: TPMA_SESSION,
+    mask: TPMA_SESSION,
+}
 
 impl TpmaSession {
-    /// Create a new session attributes object.
-    pub fn new() -> TpmaSession {
-        TpmaSession(0)
+    // Clones the TpmaSession but adds a new mask.
+    pub fn clone_with_new_mask(self, new_mask: TPMA_SESSION) -> TpmaSession {
+        TpmaSession {
+            flags: self.flags,
+            mask: new_mask,
+        }
     }
 
-    /// Set flag.
+    /// Function to retrieve the masks
+    /// that have been set.
+    pub fn mask(self) -> TPMA_SESSION {
+        self.mask
+    }
+
+    /// Function to retrive the flags that
+    /// gave been set.
+    pub fn flags(self) -> TPMA_SESSION {
+        self.flags
+    }
+}
+
+/// A builder for TpmaSession.
+///
+/// If no mask have been added then the mask
+/// will be set till all flags.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct TpmaSessionBuilder {
+    flags: TPMA_SESSION,
+    mask: Option<TPMA_SESSION>,
+}
+
+impl TpmaSessionBuilder {
+    pub fn new() -> TpmaSessionBuilder {
+        TpmaSessionBuilder {
+            flags: 0,
+            mask: None,
+        }
+    }
+
+    /// Function used to add flags.
     pub fn with_flag(mut self, flag: TPMA_SESSION) -> Self {
-        self.0 |= flag;
+        self.flags |= flag;
         self
     }
 
-    /// Get mask for all set flags.
-    pub fn mask(self) -> TPMA_SESSION {
-        self.0
+    /// Function used to add masks.
+    pub fn with_mask(mut self, mask: TPMA_SESSION) -> Self {
+        self.mask = Some(self.mask.unwrap_or(0) | mask);
+        self
     }
 
-    /// Get all set flags.
-    pub fn flags(self) -> TPMA_SESSION {
-        self.0
+    /// Function used to build a TpmaSession
+    /// from the parameters that have been
+    /// added.
+    pub fn build(self) -> TpmaSession {
+        TpmaSession {
+            flags: self.flags,
+            mask: self.mask.unwrap_or(self.flags),
+        }
     }
 }
 


### PR DESCRIPTION
* Added more TPM resource API:s

Added more of the ESYS TOM Resource API:s. Some of the API:s already existed with
some extended functionality or a different name. I changed this to call new functions
that are only thin wrappers around the original C API:s. The reason for the changes is
to keep the naming consistent.

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>

* Fixed names.

Fixed the names of the TPM2 Resource API wrapper functions.
Removed the duplicates previously created in order to be
backward compatible.

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>

* Fixed name change in tests.

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>

* Improved TpmaSession

The TpmaSession have now been split up into two parts.
The first part the actual TpmaSession struct now only
holds the values for the mask and the flags and that is
all it is responsible for.
The TpmaSessionBuilder struct provides utility
functions that makes it easier to create a TpmaSession
object.

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>

* Fixed tests that failed to build

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>